### PR TITLE
Download support

### DIFF
--- a/inspector/ios-inspector/ForgeModule/tabs_ConnectionDelegate.h
+++ b/inspector/ios-inspector/ForgeModule/tabs_ConnectionDelegate.h
@@ -1,5 +1,5 @@
 //
-//  tabs_LoginDialogDelegate.h
+//  tabs_ConnectionDelegate.h
 //  ForgeModule
 //
 //  Created by Antoine van Gelder on 2017/03/16.

--- a/inspector/ios-inspector/ForgeModule/tabs_ConnectionDelegate.m
+++ b/inspector/ios-inspector/ForgeModule/tabs_ConnectionDelegate.m
@@ -1,5 +1,5 @@
 //
-//  tabs_LoginDialogDelegate.m
+//  tabs_ConnectionDelegate.m
 //  ForgeModule
 //
 //  Created by Antoine van Gelder on 2017/03/16.
@@ -212,6 +212,7 @@
     }
 
     NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse*)response;
+    
     NSString *status = [NSHTTPURLResponse localizedStringForStatusCode:httpResponse.statusCode];
     NSString *responseString = [NSString stringWithFormat:@"%@", httpResponse];
 
@@ -237,6 +238,7 @@
     
     // remember the current url until response body is loaded
     currentUrl = [NSURL URLWithString:responseURL];
+    
 }
 
 

--- a/inspector/ios-inspector/ForgeModule/tabs_modalWebViewController.m
+++ b/inspector/ios-inspector/ForgeModule/tabs_modalWebViewController.m
@@ -493,6 +493,14 @@ static UIBarButtonItem *reload = nil;
                                               otherButtonTitles:nil];
         [alert show];
     }
+    if (error.code == 102) {
+        NSString *URLString = [error.userInfo objectForKey:@"NSErrorFailingURLStringKey"];
+        NSURL *failedRequestURL = [NSURL URLWithString:URLString];
+        // Determine if we want the system to handle it.
+        if ([[UIApplication sharedApplication]canOpenURL:failedRequestURL]) {
+            [[UIApplication sharedApplication]openURL:failedRequestURL];
+        }
+    }
     [ForgeLog w:[NSString stringWithFormat:@"Modal webview error: %@", error]];
     [[ForgeApp sharedApp] event:[NSString stringWithFormat:@"tabs.%@.loadError", task.callid] withParam:@{@"url": self.webView.request.URL.absoluteString, @"description": error.description}];
 }

--- a/module/manifest.json
+++ b/module/manifest.json
@@ -1,8 +1,8 @@
 {
-    "changes": "* Improvements to iOS Basic Auth handling (tx @scthi and @prud!)",
-    "description": "APIs to deal with opening browser tabs and external sites within your app.\n\nThe tabs module allows you to open external sites in an un-trusted popup view that your users can close at any point.",
-    "min_platform_version": "v2.6.5",
-    "namespace": "tabs",
-    "platform_version": "v2.6.5",
+    "changes": "* Added error handling for frame load interrupted error to open URL in Safari",
+    "description": "APIs to deal with opening browser tabs and external sites within your app.\n\nThe tabs module allows you to open external sites in an un-trusted popup view that your users can close at any point.", 
+    "min_platform_version": "v2.6.5", 
+    "namespace": "tabs", 
+    "platform_version": "v2.6.5", 
     "version": "2.20"
 }

--- a/module/tests/interactive.js
+++ b/module/tests/interactive.js
@@ -2,6 +2,24 @@
 
 module("forge.tabs");
 
+asyncTest("Open tab with downloads", 1, function() {
+    forge.tabs.open("https://req-playground-ahghagcnmb.now.sh/downloads", function () {
+        askQuestion("Have you been able to open the files listed on the download page?", {
+            Yes: function () {
+                ok(true, "Success");
+                start();
+            },
+            No: function () {
+                ok(false, "User claims failure");
+                start();
+            }
+        });
+    }, function (e) {
+        ok(false, "API call failure: "+e.message);
+        start();
+    });
+});
+
 asyncTest("Open tab with website", 1, function() {
     forge.tabs.open("https://trigger.io", function () {
         askQuestion("Did a tab/view just open in the foreground with the Trigger.io website?", {


### PR DESCRIPTION
The UIWebView sends frame `load interrupted error` when the URL cannot be loaded. We catch this exception and open it in Safari if possible.